### PR TITLE
1.0.0~alpha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# python-twitch for Kodi (script.module.python.twitch)
+# python-twitch for Kodi 
+###### script.module.python.twitch
 
-# Currently Staging * Untested/Not working
+python-twitch for Kodi is module for interaction with the Twitch.tv API
 
-This Kodi module is a based on python-twitch https://github.com/ingwinlu/python-twitch. Thanks to ingwinlu for his continued work on the project.
+#### Usage:
+Example can be found <link to Twitch on Kodi (v2) api module>
+
+#### API Documentation:
+https://dev.twitch.tv/docs
+
+---
+This Kodi module is a based on python-twitch https://github.com/ingwinlu/python-twitch
+Thanks to ingwinlu for his continued work on the project.

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.python-twitch" name="python-twitch for Kodi" version="1.0.0~alpha1" provider-name="A Talented Community">
+<addon id="script.module.python.twitch" name="python-twitch for Kodi" version="1.0.0~alpha1" provider-name="A Talented Community">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.six" version="1.9.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,15 @@
     <extension point="xbmc.python.module" library="resources/lib"/>
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
-        <summary lang="en">A fork of python-twitch, for Kodi</summary>
+        <news>
+All New!
+        </news>
+        <assets>
+            <icon>icon.png</icon>
+            <fanart>fanart.jpg</fanart>
+        </assets>
+        <platform>all</platform>
+        <summary lang="en">A fork of python-twitch for Kodi</summary>
         <description lang="en">python-twitch for Kodi is module for interaction with the Twitch.tv API based on python-twitch by ingwinlu.</description>
         <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
         <forum> </forum>

--- a/addon.xml
+++ b/addon.xml
@@ -3,6 +3,7 @@
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.six" version="1.9.0"/>
+        <import addon="script.module.requests" version="2.9.1"/>
     </requires>
     <extension point="xbmc.python.module" library="resources/lib"/>
     <extension point="xbmc.addon.metadata">

--- a/addon.xml
+++ b/addon.xml
@@ -9,7 +9,15 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <news>
-All New!
+- initial release
+- use script.module.requests
+- remove default client_id
+- add oauth token support
+- add authorization, client id headers to all api calls
+- update api.twitch to use https
+- update usher to allow_source
+- videos.by_channel from broadcasts bool to broadcast_type: 'archive', 'highlight', 'upload'
+- update m3u_pattern
         </news>
         <assets>
             <icon>icon.png</icon>

--- a/addon.xml
+++ b/addon.xml
@@ -24,7 +24,7 @@
             <fanart>fanart.jpg</fanart>
         </assets>
         <platform>all</platform>
-        <summary lang="en">A fork of python-twitch for Kodi</summary>
+        <summary lang="en">Module for interaction with the Twitch.tv API</summary>
         <description lang="en">python-twitch for Kodi is module for interaction with the Twitch.tv API based on python-twitch by ingwinlu.</description>
         <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
         <forum> </forum>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,10 @@
+1.0.0
+- initial release
+- use script.module.requests
+- remove default client_id
+- add oauth token support
+- add authorization, client id headers to all api calls
+- update api.twitch to use https
+- update usher to allow_source
+- videos.by_channel from broadcasts bool to broadcast_type: 'archive', 'highlight', 'upload'
+- update m3u_pattern

--- a/resources/lib/twitch/__init__.py
+++ b/resources/lib/twitch/__init__.py
@@ -2,3 +2,4 @@
 
 VERSION = '1.3.0'
 CLIENT_ID = ''
+OAUTH_TOKEN = ''

--- a/resources/lib/twitch/__init__.py
+++ b/resources/lib/twitch/__init__.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 VERSION = '1.3.0'
-CLIENT_ID = 'conc17x2vpauvp2youhs3legi90c6jx'
+CLIENT_ID = ''

--- a/resources/lib/twitch/api/usher.py
+++ b/resources/lib/twitch/api/usher.py
@@ -40,7 +40,7 @@ def live(channel):
     q.add_urlkw(keys.CHANNEL, channel)
     q.add_param(keys.SIG, token[keys.SIG])
     q.add_param(keys.TOKEN, token[keys.TOKEN])
-    q.add_param(keys.ALLOW_SOURCE, Boolean.FALSE)
+    q.add_param(keys.ALLOW_SOURCE, Boolean.TRUE)
     return q
 
 
@@ -55,6 +55,7 @@ def _vod(id):
     q.add_urlkw(keys.ID, id)
     q.add_param(keys.NAUTHSIG, token[keys.SIG])
     q.add_param(keys.NAUTH, token[keys.TOKEN])
+    q.add_param(keys.ALLOW_SOURCE, Boolean.TRUE)
     return q
 
 

--- a/resources/lib/twitch/api/v3/videos.py
+++ b/resources/lib/twitch/api/v3/videos.py
@@ -28,12 +28,12 @@ def top(limit=10, offset=0, game=None, period=Period.WEEK):
 
 @query
 def by_channel(name, limit=10, offset=0,
-               broadcasts=Boolean.FALSE, hls=Boolean.FALSE):
+               broadcast_type=keys.ARCHIVE, hls=Boolean.FALSE):
     q = Qry('channels/{channel}/videos')
     q.add_urlkw(keys.CHANNEL, name)
     q.add_param(keys.LIMIT, limit, 10)
     q.add_param(keys.OFFSET, offset, 0)
-    q.add_param(keys.BROADCASTS, Boolean.validate(broadcasts), Boolean.FALSE)
+    q.add_param(keys.BROADCAST_TYPE, broadcast_type, keys.ARCHIVE)
     q.add_param(keys.HLS, Boolean.validate(hls), Boolean.FALSE)
     return q
 

--- a/resources/lib/twitch/keys.py
+++ b/resources/lib/twitch/keys.py
@@ -35,3 +35,7 @@ USER_AGENT = 'User-Agent'
 USER_AGENT_STRING = ('Mozilla/5.0 (Windows NT 6.1; WOW64; rv:6.0) '
                      'Gecko/20100101 Firefox/6.0')
 VOD = 'vod'
+BROADCAST_TYPE = 'broadcast_type'
+ARCHIVE = 'archive'
+UPLOAD = 'upload'
+HIGHLIGHT = 'highlight'

--- a/resources/lib/twitch/parser.py
+++ b/resources/lib/twitch/parser.py
@@ -4,7 +4,7 @@ import re
 from twitch.logging import log
 
 _m3u_pattern = re.compile(
-        r'#EXT-X-MEDIA:.*'
+        r'#EXT-X-MEDIA:TYPE=VIDEO.*'
         r'GROUP-ID="(?P<group_id>.\w*)",'
         r'NAME="(?P<group_name>\w*)"[,=\w]*\n'
         r'#EXT-X-STREAM-INF:.*\n('

--- a/resources/lib/twitch/queries.py
+++ b/resources/lib/twitch/queries.py
@@ -8,7 +8,7 @@ from twitch.logging import log
 from twitch.scraper import download, get_json
 
 _kraken_baseurl = 'https://api.twitch.tv/kraken/'
-_hidden_baseurl = 'http://api.twitch.tv/api/'
+_hidden_baseurl = 'https://api.twitch.tv/api/'
 _usher_baseurl = 'http://usher.twitch.tv/'
 
 _v2_headers = {'ACCEPT': 'application/vnd.twitchtv.v2+json'}

--- a/resources/lib/twitch/queries.py
+++ b/resources/lib/twitch/queries.py
@@ -87,6 +87,7 @@ class ApiQuery(JsonQuery):
 
 class HiddenApiQuery(JsonQuery):
     def __init__(self, path, headers={}):
+        headers.setdefault('Client-Id', CLIENT_ID)
         super(HiddenApiQuery, self).__init__(_hidden_baseurl, headers)
         self.add_path(path)
 

--- a/resources/lib/twitch/queries.py
+++ b/resources/lib/twitch/queries.py
@@ -2,7 +2,7 @@
 
 from six.moves.urllib.parse import urljoin
 
-from twitch import CLIENT_ID
+from twitch import CLIENT_ID, OAUTH_TOKEN
 from twitch.exceptions import ResourceUnavailableException
 from twitch.logging import log
 from twitch.scraper import download, get_json
@@ -81,6 +81,7 @@ class JsonQuery(_Query):
 class ApiQuery(JsonQuery):
     def __init__(self, path, headers={}):
         headers.setdefault('Client-Id', CLIENT_ID)
+        headers.setdefault('Authorization', 'OAuth {access_token}'.format(access_token=OAUTH_TOKEN))
         super(ApiQuery, self).__init__(_kraken_baseurl, headers)
         self.add_path(path)
 
@@ -88,12 +89,15 @@ class ApiQuery(JsonQuery):
 class HiddenApiQuery(JsonQuery):
     def __init__(self, path, headers={}):
         headers.setdefault('Client-Id', CLIENT_ID)
+        headers.setdefault('Authorization', 'OAuth {access_token}'.format(access_token=OAUTH_TOKEN))
         super(HiddenApiQuery, self).__init__(_hidden_baseurl, headers)
         self.add_path(path)
 
 
 class UsherQuery(DownloadQuery):
     def __init__(self, path, headers={}):
+        headers.setdefault('Client-Id', CLIENT_ID)
+        headers.setdefault('Authorization', 'OAuth {access_token}'.format(access_token=OAUTH_TOKEN))
         super(UsherQuery, self).__init__(_usher_baseurl, headers)
         self.add_path(path)
 

--- a/resources/lib/twitch/scraper.py
+++ b/resources/lib/twitch/scraper.py
@@ -1,9 +1,10 @@
 # -*- encoding: utf-8 -*-
-import six
+import requests
+# import six
 from six.moves.urllib.error import URLError
 from six.moves.urllib.parse import quote_plus  # NOQA
 from six.moves.urllib.parse import urlencode
-from six.moves.urllib.request import Request, urlopen
+# from six.moves.urllib.request import Request, urlopen
 
 from twitch.keys import USER_AGENT, USER_AGENT_STRING
 from twitch.logging import log
@@ -41,14 +42,9 @@ def download(baseurl, parameters={}, headers={}):
     data = ""
     for _ in range(MAX_RETRIES):
         try:
-            req = Request(url, headers=headers)
-            req.add_header(USER_AGENT, USER_AGENT_STRING)
-            response = urlopen(req)
-            if six.PY2:
-                data = response.read()
-            else:
-                data = response.read().decode('utf-8')
-            response.close()
+            headers.update({USER_AGENT: USER_AGENT_STRING})
+            response = requests.get(url, headers=headers)
+            data = response.content
             break
         except Exception as err:
             if not isinstance(err, URLError):


### PR DESCRIPTION
use script.module.requests
remove default client_id
add oauth token support
add authorization, client id headers to all api calls
update api.twitch to use https
update usher to allow_source
videos.by_channel from broadcasts bool to broadcast_type: 'archive', 'highlight', 'upload'
update m3u_pattern