### PR TITLE
Do not use OAuth token for video-by-id queries

### DIFF
--- a/resources/lib/twitch/api/v5/videos.py
+++ b/resources/lib/twitch/api/v5/videos.py
@@ -12,7 +12,7 @@ from twitch.queries import query
 # required scope: none
 @query
 def by_id(video_id):
-    q = Qry('videos/{video_id}')
+    q = Qry('videos/{video_id}', use_token=False)
     q.add_urlkw(keys.VIDEO_ID, video_id)
     return q
 

--- a/resources/lib/twitch/queries.py
+++ b/resources/lib/twitch/queries.py
@@ -105,9 +105,9 @@ class JsonQuery(_Query):
 
 
 class ApiQuery(JsonQuery):
-    def __init__(self, path, headers={}, data={}, method=methods.GET):
+    def __init__(self, path, headers={}, data={}, use_token=True, method=methods.GET):
         headers.setdefault('Client-ID', CLIENT_ID)
-        if OAUTH_TOKEN:
+        if use_token and OAUTH_TOKEN:
             headers.setdefault('Authorization', 'OAuth {access_token}'.format(access_token=OAUTH_TOKEN))
         super(ApiQuery, self).__init__(_kraken_baseurl, headers, data, method)
         self.add_path(path)
@@ -144,8 +144,8 @@ class UploadsQuery(DownloadQuery):
 
 
 class V5Query(ApiQuery):
-    def __init__(self, path, method=methods.GET):
-        super(V5Query, self).__init__(path, _v5_headers, method=method)
+    def __init__(self, path, use_token=True, method=methods.GET):
+        super(V5Query, self).__init__(path, _v5_headers, use_token=use_token, method=method)
 
 
 def assert_new(d, k):


### PR DESCRIPTION
They started to fail with '401: authentication failed'.

It seems that these requests do not require authentication, according to
twitch API documentation:
https://dev.twitch.tv/docs/v5/reference/videos/#get-video
"""
Get Video
Gets a specified video object.

Authentication
None

URL
GET https://api.twitch.tv/kraken/videos/<video ID>

Optional Query String Parameters
None
"""