### PR TITLE
usher: add optional supported_codecs parameter

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.python.twitch" name="python-twitch for Kodi" version="3.0.2" provider-name="anxdpanic, A Talented Community">
+<addon id="script.module.python.twitch" name="python-twitch for Kodi" version="3.0.3" provider-name="anxdpanic, A Talented Community">
     <requires>
         <import addon="xbmc.python" version="3.0.1"/>
         <import addon="script.module.six" version="1.11.0"/>
@@ -9,7 +9,7 @@
     <extension point="xbmc.addon.metadata">
         <platform>all</platform>
         <news>
-[fix] Following Channels
+[add] optional supported_codecs parameter for usher requests
         </news>
         <assets>
             <icon>resources/media/icon.png</icon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+3.0.3
+[add] usher: optional supported_codecs parameter (e.g. 'h265,h264') threaded through live/vod/clip
+      requests; omitted by default so existing behaviour is unchanged
+
 3.0.0
 [rem] removed support for Kodi versions pre-Nexus v20
 [rem] removed python 2 support

--- a/resources/lib/twitch/api/usher.py
+++ b/resources/lib/twitch/api/usher.py
@@ -88,7 +88,7 @@ def _legacy_video(video_id):
     return q
 
 
-def live_request(channel, platform=keys.WEB, headers={}):
+def live_request(channel, platform=keys.WEB, headers={}, supported_codecs=None):
     token = channel_token(channel, platform=platform, headers=headers)
     token = get_access_token(token)
 
@@ -112,6 +112,8 @@ def live_request(channel, platform=keys.WEB, headers={}):
         q.add_param(keys.PLAYLIST_INCLUDE_FRAMERATE, Boolean.TRUE)
         q.add_param(keys.RTQOS, keys.CONTROL)
         q.add_param(keys.PLAYER_BACKEND, keys.MEDIAPLAYER)
+        if supported_codecs:
+            q.add_param('supported_codecs', supported_codecs)
         url = '?'.join([q.url, urlencode(q.params)])
         request_dict = {
             'url': url,
@@ -122,7 +124,7 @@ def live_request(channel, platform=keys.WEB, headers={}):
 
 
 @query
-def _live(channel, token, headers={}):
+def _live(channel, token, headers={}, supported_codecs=None):
     signature = token[keys.SIGNATURE]
     access_token = token[keys.VALUE]
 
@@ -139,11 +141,13 @@ def _live(channel, token, headers={}):
     q.add_param(keys.PLAYLIST_INCLUDE_FRAMERATE, Boolean.TRUE)
     q.add_param(keys.RTQOS, keys.CONTROL)
     q.add_param(keys.PLAYER_BACKEND, keys.MEDIAPLAYER)
+    if supported_codecs:
+        q.add_param('supported_codecs', supported_codecs)
     return q
 
 
 @m3u8
-def live(channel, platform=keys.WEB, headers={}):
+def live(channel, platform=keys.WEB, headers={}, supported_codecs=None):
     token = channel_token(channel, platform=platform, headers=headers)
     token = get_access_token(token)
     if not token:
@@ -151,10 +155,10 @@ def live(channel, platform=keys.WEB, headers={}):
     elif isinstance(token, dict) and 'error' in token:
         return token
     else:
-        return _live(channel, token, headers=headers)
+        return _live(channel, token, headers=headers, supported_codecs=supported_codecs)
 
 
-def video_request(video_id, platform=keys.WEB, headers={}):
+def video_request(video_id, platform=keys.WEB, headers={}, supported_codecs=None):
     video_id = valid_video_id(video_id)
     if video_id:
         token = vod_token(video_id, platform=platform, headers=headers)
@@ -178,6 +182,8 @@ def video_request(video_id, platform=keys.WEB, headers={}):
             q.add_param(keys.PLAYLIST_INCLUDE_FRAMERATE, Boolean.TRUE)
             q.add_param(keys.RTQOS, keys.CONTROL)
             q.add_param(keys.PLAYER_BACKEND, keys.MEDIAPLAYER)
+            if supported_codecs:
+                q.add_param('supported_codecs', supported_codecs)
             q.add_param(keys.BAKING_BREAD, Boolean.TRUE)
             q.add_param(keys.BAKING_BROWNIES, Boolean.TRUE)
             q.add_param(keys.BAKING_BROWNIES_TIMEOUT, 1050)
@@ -193,7 +199,7 @@ def video_request(video_id, platform=keys.WEB, headers={}):
 
 
 @query
-def _vod(video_id, token, headers={}):
+def _vod(video_id, token, headers={}, supported_codecs=None):
     signature = token[keys.SIGNATURE]
     access_token = token[keys.VALUE]
 
@@ -208,6 +214,8 @@ def _vod(video_id, token, headers={}):
     q.add_param(keys.PLAYLIST_INCLUDE_FRAMERATE, Boolean.TRUE)
     q.add_param(keys.RTQOS, keys.CONTROL)
     q.add_param(keys.PLAYER_BACKEND, keys.MEDIAPLAYER)
+    if supported_codecs:
+        q.add_param('supported_codecs', supported_codecs)
     q.add_param(keys.BAKING_BREAD, Boolean.TRUE)
     q.add_param(keys.BAKING_BROWNIES, Boolean.TRUE)
     q.add_param(keys.BAKING_BROWNIES_TIMEOUT, 1050)
@@ -215,7 +223,7 @@ def _vod(video_id, token, headers={}):
 
 
 @m3u8
-def video(video_id, platform=keys.WEB, headers={}):
+def video(video_id, platform=keys.WEB, headers={}, supported_codecs=None):
     video_id = valid_video_id(video_id)
     if video_id:
         token = vod_token(video_id, platform=platform, headers=headers)
@@ -226,7 +234,7 @@ def video(video_id, platform=keys.WEB, headers={}):
         elif isinstance(token, dict) and 'error' in token:
             return token
         else:
-            return _vod(video_id, token, headers=headers)
+            return _vod(video_id, token, headers=headers, supported_codecs=supported_codecs)
     else:
         raise NotImplementedError('Unknown Video Type')
 


### PR DESCRIPTION
## Summary
Adds an optional `supported_codecs` keyword to the usher playlist requests so callers can opt in to Twitch **Enhanced Broadcasting** codecs (e.g. HEVC), which is what unlocks the 1440p+ variants.

## Details
- `live`, `_live`, `video`, `_vod`, `live_request`, `video_request` gain `supported_codecs=None`.
- When set, `supported_codecs=<value>` is added to the usher query (e.g. `h265,h264`).
- **Default `None` → no parameter added → current behaviour unchanged** (no regression).

## Why
Twitch only returns HEVC (and the 1440p/4K variants that use it) when the client announces `supported_codecs`. Without it, 2K streams can fail to play (anxdpanic/plugin.video.twitch#699, #700). This is the library-side enabler; a companion plugin PR adds a user setting that passes the value here. The parameter is codec-agnostic, so future codecs (e.g. AV1) need no further library change.
